### PR TITLE
Android security 11.0.0 release 58

### DIFF
--- a/media/extractors/mp4/MPEG4Extractor.cpp
+++ b/media/extractors/mp4/MPEG4Extractor.cpp
@@ -4573,7 +4573,7 @@ status_t MPEG4Extractor::updateAudioTrackInfoFromESDS_MPEG4Audio(
         if (len2 == 0) {
             return ERROR_MALFORMED;
         }
-        if (offset >= csd_size || csd[offset] != 0x01) {
+        if (offset + len1 > csd_size || csd[offset] != 0x01) {
             return ERROR_MALFORMED;
         }
         // formerly kKeyVorbisInfo


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r58' of https://android.googlesource.com/platform/frameworks/av into arrow-11.0

Android security 11.0.0 release 58
Tag: https://android.googlesource.com/platform/frameworks/av/+/refs/tags/android-security-11.0.0_r58

Merge cherrypicks of [18492389] into security-aosp-rvc-release.

Change-Id: [I34c01c4017907358b3833efaed96e711e64b7ec4](https://android-review.googlesource.com/#/q/I34c01c4017907358b3833efaed96e711e64b7ec4)