### PR TITLE
Android security 11.0.0 release 59

### DIFF
--- a/media/libstagefright/timedtext/TextDescriptions.cpp
+++ b/media/libstagefright/timedtext/TextDescriptions.cpp
@@ -466,6 +466,10 @@ status_t TextDescriptions::extract3GPPGlobalDescriptions(
 
                 if (subChunkType == FOURCC('f', 't', 'a', 'b'))
                 {
+                    if(subChunkSize < 8) {
+                        return OK;
+                    }
+
                     tmpData += 8;
                     size_t subChunkRemaining = subChunkSize - 8;
 


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r59' of https://android.googlesource.com/platform/frameworks/av into arrow-11.0

Android security 11.0.0 release 59
Tag: https://android.googlesource.com/platform/frameworks/av/+/refs/tags/android-security-11.0.0_r59

Merge cherrypicks of [18993507] into security-aosp-rvc-release.

Change-Id: [I4e3b150d27093cecdc4fbfd7c9c0e5408c281053](https://android-review.googlesource.com/#/q/I4e3b150d27093cecdc4fbfd7c9c0e5408c281053)